### PR TITLE
Switch to complete oAuth authentication, reconnect to socket on fail, cache tokens

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,9 +9,15 @@ const crypto = require("crypto");
 const io = require('socket.io-client');
 const logger = require('debug')('ring-alarm');
 const logger2 = require('debug')('ring-alarm.station');
+const fs = require('fs');
+
+const homeDir = require('os').homedir();
+const path = require('path');
+const cacheFile = ".ringAlarmCache";
 
 const API_VERSION = 11;
-const hardware_id = crypto.randomBytes(16).toString("hex");
+//Generate random hardware ID unless a saved one is found
+let hardware_id = crypto.randomBytes(16).toString("hex");
 
 const formatDates = (key, value) => {
     if (value && value.indexOf && value.indexOf('.000Z') > -1) {
@@ -53,12 +59,15 @@ class Doorbot {
         this.timeout = options.timeout || (5 * 60 * 1000);
         this.counter = 0;
         this.userAgent = options.userAgent || 'android:com.ringapp:2.0.67(423)';
-        this.token = options.token || null;
         this.oauthToken = options.oauthToken || null;
         this.alarmSockets = {};
+        //One time callbacks - send a message and receive a response once
         this.alarmCallbacks = {};
+        //Repeatable callbacks - receive a callback for all of the same message type
+        this.alarmGenericCallbacks = {};
         this.seqno = 1;
         this.api_version = options.api_version || API_VERSION;
+        this.cacheDir = options.cacheDir || homeDir;
 
         if (!this.username) {
             throw(new Error('username is required'));
@@ -66,37 +75,151 @@ class Doorbot {
         if (!this.password) {
             throw(new Error('password is required'));
         }
+
+        this.loadingCache = false;
+        this.cacheQueue = [];
+        this._loadCache(this.cacheDir);
         this.authenticating = false;
         this.authQueue = [];
     }
 
+    _loadCache(cacheDir){
+        this.loadingCache = true;
+        fs.readFile(path.join(cacheDir,cacheFile), 'utf8', (err, data) => {
+            this.loadingCache = false;
+            if(!err) {
+                let jsonData = JSON.parse(data);
+                hardware_id = jsonData.hardware_id;
+                this.oauthToken = jsonData.oauthToken;
+                this.refreshToken = jsonData.refreshToken;
+                logger("found cached data: " + stringify(jsonData));
+            }
+            else
+                logger('error loading cached data' + err);
+            if (this.cacheQueue.length) {
+                logger(`Clearing ${this.cacheQueue.length} callbacks from the cache queue`);
+                this.cacheQueue.forEach(_cb => {
+                    return _cb();
+                });
+                this.cacheQueue = [];
+            }
+        });
+    }
+
+    _writeCache(){
+        let outObj = {
+            oauthToken: this.oauthToken,
+            refreshToken: this.refreshToken,
+            hardware_id: hardware_id
+        };
+        let outStr = JSON.stringify(outObj);
+        fs.writeFile(path.join(this.cacheDir, cacheFile), outStr, 'utf8', (err) => {
+            if(err) logger('failed to persist token data' + err);
+            else logger('successfully saved token data');
+        });
+    }
+
+    _loginOauth(callback, type){
+        logger('authenticating with oAuth...');
+        let body;
+        if(type === "login")
+            body = JSON.stringify({
+                client_id: "ring_official_android",
+                grant_type: "password",
+                username: this.username,
+                password: this.password,
+                scope: "client"
+            });
+        else if(type === "refresh")
+            body = JSON.stringify({
+                client_id: "ring_official_android",
+                grant_type: "refresh_token",
+                refresh_token: this.refreshToken,
+                scope: "client"
+            });
+
+        const url = parse('https://oauth.ring.com/oauth/token');
+        url.method = 'POST';
+        url.headers = {
+            'content-type': 'application/json',
+            'content-length': body.length
+        };
+        logger('fetching access_token from oAuth token endpoint');
+        const req = https.request(url, (res) => {
+            logger('access_token statusCode', res.statusCode);
+            logger('access_token headers', res.headers);
+            let data = '';
+            res.on('data', d => {return data += d;});
+            res.on('end', () => {
+                let e = null;
+                let json = null;
+                try {
+                    json = JSON.parse(data);
+                } catch (je) {
+                    logger('JSON parse error', data);
+                    logger(je);
+                    e = new Error('JSON parse error from ring, check logging..');
+                }
+                let token = null;
+                if (json && json.access_token && json.refresh_token) {
+                    token = json.access_token;
+                    this.oauthToken = token;
+                    this.refreshToken = json.refresh_token;
+                    logger('authentication_token', token);
+                    this._writeCache();
+                }
+                if (!token || e) {
+                    logger('access_token request failed, bailing..');
+                    e = e || new Error('API failed to return an authentication_token');
+                    return callback(e);
+                }
+                return callback(null, token);
+            });
+        });
+        req.on('error', callback);
+        req.write(body);
+        req.end();
+    }
+
+    _getOauthToken(callback){
+        if(this.refreshToken){
+            logger('found refresh token, attempting to refresh');
+            this._loginOauth((e, token) => {
+               if(e) {
+                   logger("oAuth refresh failed, attempting login");
+                   return this._loginOauth(callback, "login");
+               }
+               logger("successfully refreshed oAuth token");
+               return callback(e, token);
+            }, "refresh");
+        }
+        else{
+            return this._loginOauth(callback, "login");
+        }
+    }
+
     _fetch(method, url, query, body, callback) {
         logger('fetch:', this.counter, method, url);
-        var d = parse(url, true);
-        var altAPI;
+        let d = parse(url, true);
         if (url.indexOf('http') === -1)
             d = parse('https://api.ring.com/clients_api' + url, true);
-        else {
-            altAPI = true;
-        }
         logger('query', query);
         delete d.path;
         delete d.href;
         delete d.search;
-        
+
         /*istanbul ignore next*/
         if (query) {
             Object.keys(query).forEach((key) => {
                 d.query[key] = query[key];
             });
         }
-    
+
         d = parse(format(d), true);
         logger('fetch-data', d);
         d.method = method;
         d.headers = d.headers || {};
-        if (altAPI)
-            d.headers.Authorization = "Bearer " + this.oauthToken;
+        d.headers.Authorization = "Bearer " + this.oauthToken;
         if (body) {
             body = stringify(body);
             d.headers['content-type'] = 'application/x-www-form-urlencoded';
@@ -110,7 +233,7 @@ class Doorbot {
             if (timeoutP) {
                 return;
             }
-            var data = '';
+            let data = '';
             res.on('data', (d) => {
                 data += d;
             });
@@ -121,7 +244,7 @@ class Doorbot {
             res.on('end', () => {
                 req.setTimeout(0);
                 logger('fetch-raw-data', data);
-                var json,
+                let json,
                     e = null;
                 try {
                     data = _scrub(data);
@@ -168,8 +291,7 @@ class Doorbot {
                 return callback(e);
             }
             this._fetch(method, url, {
-                api_version: this.api_version,
-                auth_token: this.token
+                api_version: this.api_version
             }, data, (e, res, json) => {
                 /*istanbul ignore else - It's only for logging..*/
                 if (json) {
@@ -180,7 +302,7 @@ class Doorbot {
                 if (e && e.code === 401 && this.counter < this.retries) {
                     logger('auth failed, retrying', e);
                     this.counter += 1;
-                    var self = this;
+                    let self = this;
                     setTimeout(() => {
                         logger('auth failed, retry', { counter: self.counter });
                         self.token = self.oauthToken = null;
@@ -205,8 +327,15 @@ class Doorbot {
             callback = retryP;
             retryP = false;
         }
+        if(this.loadingCache){
+            logger("Cache read in progress. Queuing auth");
+            this.cacheQueue.push(() => {
+                this._authenticate(retryP, callback);
+            });
+            return;
+        }
         if (!retryP) {
-            if (this.token) {
+            if (this.oauthToken) {
                 logger('auth skipped, we have a token');
                 return callback();
             }
@@ -217,114 +346,19 @@ class Doorbot {
             }
             this.authenticating = true;
         }
-        logger('authenticating with oAuth...');
-        const body = JSON.stringify({
-            client_id: "ring_official_android",
-            grant_type: "password",
-            username: this.username,
-            password: this.password,
-            scope: "client"
-        });
-        const url = parse('https://oauth.ring.com/oauth/token');
-        url.method = 'POST';
-        url.headers = {
-            'content-type': 'application/json',
-            'content-length': body.length
-        };
-        logger('fetching access_token from oAuth token endpoint');
-        const req = https.request(url, (res) => {
-            logger('access_token statusCode', res.statusCode);
-            logger('access_token headers', res.headers);
-            let data = '';
-            res.on('data', d => {return data += d;});
-            res.on('end', () => {
-                let e = null;
-                let json = null;
-                try {
-                    json = JSON.parse(data);
-                } catch (je) {
-                    logger('JSON parse error', data);
-                    logger(je);
-                    e = new Error('JSON parse error from ring, check logging..');
-                }
-                let token = null;
-                let oauthToken = null;
-                if (json && json.access_token) {
-                    token = json.access_token;
-                    oauthToken = token;
-                    logger('authentication_token', token);
-                }
-                if (!token || e) {
-                    logger('access_token request failed, bailing..');
-                    e = e || new Error('API failed to return an authentication_token');
-                    return callback(e);
-                }
-                const body = JSON.stringify({
-                    device: {
-                        hardware_id: hardware_id,
-                        metadata: {
-                            api_version: this.api_version,
-                        },
-                        os: "android"
-                    }
+        let self = this;
+        this._getOauthToken((err, token) => {
+            if(err)  return callback(err);
+            self.authenticating = false;
+            if (self.authQueue.length) {
+                logger(`Clearing ${self.authQueue.length} callbacks from the queue`);
+                self.authQueue.forEach(_cb => {
+                    return _cb(err, token);
                 });
-                logger('session json', body);
-                const sessionURL = `https://api.ring.com/clients_api/session?api_version=${this.api_version}`;
-                logger2('sessionURL', sessionURL);
-                const u = parse(sessionURL, true);
-                u.method = 'POST';
-                u.headers = {
-                    Authorization: 'Bearer ' + token,
-                    'content-type': 'application/json',
-                    'content-length': body.length
-                };
-                logger('fetching token with oAuth access_token');
-                const a = https.request(u, (res) => {
-                    logger('token fetch statusCode', res.statusCode);
-                    logger('token fetch headers', res.headers);
-                    let data = '';
-                    let e = null;
-                    res.on('data', d => {return data += d;});
-                    res.on('end', () => {
-                        let json = null;
-                        try {
-                            json = JSON.parse(data);
-                        } catch (je) {
-                            logger('JSON parse error', data);
-                            logger(je);
-                            e = 'JSON parse error from ring, check logging..';
-                        }
-                        logger('token fetch response', json);
-                        const token = json && json.profile && json.profile.authentication_token;
-                        if (!token || e) {
-                            /*istanbul ignore next*/
-                            const msg = e || json && json.error || 'Authentication failed';
-                            return callback(new Error(msg));
-                        }
-                        //Timeout after authentication to let the token take effect
-                        //performance issue..
-                        var self = this;
-                        setTimeout(() => {
-                            self.token = token;
-                            self.oauthToken = oauthToken;
-                            self.authenticating = false;
-                            if (self.authQueue.length) {
-                                logger(`Clearing ${self.authQueue.length} callbacks from the queue`);
-                                self.authQueue.forEach(_cb => {return _cb(e, token);});
-                                self.quthQueue = [];
-                            }
-                            callback(e, token);
-                        }, 1500);
-                    });
-                });
-                a.on('error', callback);
-                a.write(body);
-                a.end();
-            });
-        });
-        req.on('error', callback);
-        req.write(body);
-        req.end();
+                self.authQueue = [];
+            }
+            return callback(null, token);
+        })
     }
 
     stations(callback) {
@@ -350,7 +384,7 @@ class Doorbot {
                 const callbacks = self.alarmCallbacks[key];
 
                 logger2(key + ': ' + err.toString());
-                self.token = self.oauthToken = null;
+                self.oauthToken = null;
 
                 delete self.alarmSockets[key];
                 delete self.alarmCallbacks[key];
@@ -365,18 +399,35 @@ class Doorbot {
                       logger ('cleanup err=' + ex.stack);
                   }
                 }
+
+                logger('Websocket disconnect detected. Attempting to reconnect');
+                self._initAlarmConnection(alarmDevice, callback);
             };
 
             if (e) return callback(e, alarmDevice);
 
             logger2('Connecting to websocket');
-            websocket = io.connect('wss://' + connection.server + '/?authcode=' + connection.authCode, { reonnection: false });
+            websocket = io.connect('wss://' + connection.server + '/?authcode=' + connection.authCode, { reconnection: false });
 
             self.alarmSockets[key] = websocket;
             self.alarmCallbacks[key] = {};
+            if(!self.alarmGenericCallbacks[key])
+                self.alarmGenericCallbacks[key] = {};
             websocket.on('connect', () => {
                 logger2('Connected to websocket');
                 callback();
+                let callbacks = self.alarmGenericCallbacks[key];
+                //Get message types (properties of object)
+                for(let messageType in callbacks){
+                    logger('Re-registering ' +
+                        callbacks.length + ' callbacks for message type ' + messageType);
+                    if(!callbacks.hasOwnProperty(messageType)) continue;
+                    //Get callbacks (elements of array)
+                    for(let callback of callbacks[messageType]){
+                        if(!callbacks[messageType].hasOwnProperty(callback)) continue;
+                        self.setAlarmCallback(alarmDevice, messageType, callback);
+                    }
+                }
             }).on('connect_error', (err) => {
                 loser(err);
                 callback(err);
@@ -408,6 +459,18 @@ class Doorbot {
 
                 self.setAlarmCallback(alarmDevice, messageType, callback);
             });
+        }
+
+        let key = alarmDevice.location_id;
+        if(!self.alarmGenericCallbacks[key][messageType]) {
+            self.alarmGenericCallbacks[key][messageType] = [];
+        }
+        if(self.alarmGenericCallbacks[key][messageType].indexOf(callback) === -1) {
+            logger('Registered callback for message type ' + messageType);
+            self.alarmGenericCallbacks[key][messageType].push(callback);
+        }
+        else{
+            logger('Callback for message type ' + messageType + ' already exists');
         }
 
         websocket.on(messageType, (message) => {
@@ -476,7 +539,7 @@ class Doorbot {
             return self._initAlarmConnection(alarmDevice, (err) => {
                 if (err) return callback(err, alarmDevice);
 
-                self.sendAlarmModel(alarmDevice, alarmPanelId, alarmMode, bypassedSensors, callback);
+                self.setAlarmMode(alarmDevice, alarmPanelId, alarmMode, bypassedSensors, callback);
             });
         }
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   "homepage": "https://github.com/homespun/ring-alarm",
   "dependencies": {
     "debug": "^2.6.8",
-    "socket.io": "^2.1.1"
+    "socket.io-client": "^2.1.1"
   }
 }


### PR DESCRIPTION
Removes old app token based authentication and switches over to oAuth based auth for all requests.
Detect oAuth token expiration, and renew tokens.
Persists oAuth token and refresh token to cache file along with hardware ID so that new hardware ID's aren't created with every session.

Adds functionality to reconnect to socket when the socket closes. I left a socket open for over 24 hours and it didn't disconnect, but confirmed that this new functionality works in the case of a temporary network failure. There's room for improvement because it will eventually fail if there's a prolonged network failure and the authentication fails. Should resolve this issue https://github.com/homespun/ring-alarm/issues/1

On socket reconnect will reinstate "generic" callbacks, which are callbacks that were set for a specific message type rather than a one time callback based on a sequence number.